### PR TITLE
Add GitHub Projects status integration for issue status detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2776,6 +2777,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2786,6 +2788,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2835,6 +2838,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -3334,6 +3338,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3632,6 +3637,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -3696,6 +3702,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4311,6 +4318,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4496,6 +4504,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6717,6 +6726,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6735,6 +6745,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7517,6 +7528,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7689,6 +7701,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8016,6 +8029,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -3,6 +3,11 @@
  *
  * Provides a complete mock Epic with batches, tasks, and dependencies
  * for testing the visualizer without requiring GitHub API access.
+ *
+ * Note: Mock data bypasses the GitHub API and GraphQL project status fetching.
+ * Status values here are set directly, simulating what would be returned after
+ * project status resolution. In production, "in-progress" status comes from
+ * either GitHub Projects v2 board status or labels like "wip"/"in progress".
  */
 
 import { Epic, Batch, Task, Dependency, IssueStatus } from "@/types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,12 +14,23 @@
  * Status of an issue based on GitHub's issue state and dependency chain
  *
  * - done: Issue is closed
- * - in-progress: Issue is open with an in-progress label
+ * - in-progress: Issue is open with an in-progress label or project status
  * - ready: Issue is open, not in-progress, and all dependencies are done
  * - blocked: Issue is open, not in-progress, and has at least one dependency that is not done
  * - unknown: Issue depends on an external issue whose status could not be determined
  */
 export type IssueStatus = "done" | "in-progress" | "ready" | "blocked" | "unknown";
+
+/**
+ * Result of fetching project statuses for issues.
+ * Contains the status map and any warnings that occurred during fetching.
+ */
+export interface ProjectStatusResult {
+  /** Map of issue number to its project status (if any) */
+  statuses: Map<number, IssueStatus>;
+  /** Warning message if project statuses couldn't be fetched (e.g., missing scope) */
+  warning?: string;
+}
 
 /**
  * GitHub Issue type - represents a single issue from the API

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -199,6 +199,17 @@ export interface Epic extends BaseIssue {
 }
 
 /**
+ * Result of fetching an Epic hierarchy.
+ * Contains the epic and any warnings that occurred during fetching.
+ */
+export interface EpicFetchResult {
+  /** The fetched epic */
+  epic: Epic;
+  /** Warning message (e.g., project status fetch failed due to missing scope) */
+  warning?: string;
+}
+
+/**
  * Loading state for async operations
  */
 export type LoadingState = "idle" | "loading" | "success" | "error";


### PR DESCRIPTION
## Problem

Issues were showing as "ready" in epic-editor even when marked as "in progress" in GitHub Projects. This is because the app only checked for in-progress **labels**, not the project board status.

## Solution

- Added GitHub Projects v2 integration to detect issue status from project boards
- Project status now takes precedence over labels when determining if an issue is "in progress" or "blocked"
- Included graceful degradation with warning toast when `read:project` scope is missing

Example epic showing in progress status

<img width="1488" height="540" alt="image" src="https://github.com/user-attachments/assets/d756d5b8-8131-4597-92aa-5efdbbad7340" />

